### PR TITLE
Feature update: separate save-to options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+
+# Results generated while testing
+Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev
+Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev.meta
+

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev.meta
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Data/Answers/testdev.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 889ddd47f1a9248bf8de1fa49096fe3d
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scenes/SampleScene.unity
@@ -474,7 +474,7 @@ PrefabInstance:
     - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: SoundOnOff
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
@@ -541,6 +541,21 @@ PrefabInstance:
       propertyPath: alsoSaveToServer
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: AlsoConsolidateResults
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SoundClipForHovering
+      value: 
+      objectReference: {fileID: 8300000, guid: d7d08c266925c5446947a004fde53aa0, type: 3}
+    - target: {fileID: 8697000387260259616, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SoundClipForSelecting
+      value: 
+      objectReference: {fileID: 8300000, guid: 7b660b21fad7af34e806c3f3c4eb8868, type: 3}
     - target: {fileID: 8697000387260259617, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: m_Name
@@ -714,6 +729,26 @@ PrefabInstance:
     - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
         type: 3}
       propertyPath: alsoSaveToServer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: UseGlobalPath
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: TargetURI
+      value: http://localhost/test-vr-questionnaire/survey-results.php
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SaveToServer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697000388396706263, guid: 93494b0f3d397d74ba1458871f004384,
+        type: 3}
+      propertyPath: SaveToLocal
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -24,13 +24,17 @@ namespace VRQuestionnaireToolkit
 {
     public class ExportToCSV : MonoBehaviour
     {
-        public string StorePath;
         public string FileName;
         public string Delimiter;
+
+        [Header("Configure if you want to save the results to local storage:")]
+        [Tooltip("Save results locally on this device.")]
+        public bool SaveToLocal = true;
+        public string StorePath;
         public bool UseGlobalPath;
 
-        [Header("If you want to save the results to a server:")]
-        public bool AlsoSaveToServer = false;
+        [Header("Configure if you want to save the results to remote server:")]
+        public bool SaveToServer = false;
         [Tooltip("The target URI to send the results to")]
         public string TargetURI = "http://www.example-server.com/survey-results.php";
 
@@ -272,7 +276,7 @@ namespace VRQuestionnaireToolkit
             outStream.Close();
 
             /* SENDING RESULTS TO SERVER */
-            if (AlsoSaveToServer)
+            if (SaveToServer)
             {
                 string allText = System.IO.File.ReadAllText(_path);
                 StartCoroutine(SendToServer(TargetURI, _completeFileName, allText));
@@ -318,7 +322,7 @@ namespace VRQuestionnaireToolkit
                     Debug.Log(ex.Message);
                 }
 
-                if (AlsoSaveToServer)
+                if (SaveToServer)
                 {
                     string allText = System.IO.File.ReadAllText(_path_allResults);
                     StartCoroutine(SendToServer(TargetURI, _completeFileName_allResults, allText));

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -268,10 +268,7 @@ namespace VRQuestionnaireToolkit
             for (int index = 0; index < length; index++)
                 sb.AppendLine(string.Join(Delimiter, output[index]));
 
-            print("Answers stored in path: " + _path);
-            StreamWriter outStream = System.IO.File.CreateText(_path);
-            outStream.WriteLine(sb);
-            outStream.Close();
+            WriteToLocal(_path, sb);
 
             /* SENDING RESULTS TO SERVER */
             if (SaveToServer)
@@ -328,6 +325,14 @@ namespace VRQuestionnaireToolkit
             }
 
             QuestionnaireFinishedEvent.Invoke(); //notify 
+        }
+
+        void WriteToLocal(string localPath, StringBuilder content)
+        {
+            print("Answers stored in path: " + localPath);
+            StreamWriter outStream = System.IO.File.CreateText(localPath);
+            outStream.WriteLine(content);
+            outStream.Close();
         }
 
         /// <summary>

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -268,13 +268,16 @@ namespace VRQuestionnaireToolkit
             for (int index = 0; index < length; index++)
                 sb.AppendLine(string.Join(Delimiter, output[index]));
 
-            WriteToLocal(_path, sb);
+            /* WRITING RESULTS TO LOCAL STORAGE */
+            if (SaveToLocal)
+            {
+                WriteToLocal(_path, sb);
+            }
 
-            /* SENDING RESULTS TO SERVER */
+            /* SENDING RESULTS TO REMOTE SERVER */
             if (SaveToServer)
             {
-                string allText = System.IO.File.ReadAllText(_path);
-                StartCoroutine(SendToServer(TargetURI, _completeFileName, allText));
+                StartCoroutine(SendToServer(TargetURI, _completeFileName, sb.ToString()));
             }
 
             /* CONSOLIDATING RESULTS */

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -129,6 +129,7 @@ namespace VRQuestionnaireToolkit
             for (int i = 1; i < _pageFactory.GetComponent<PageFactory>().NumPages - 1; i++)
                 _pageFactory.GetComponent<PageFactory>().PageList[i].SetActive(true);
 
+            #region CONSTRUCTING RESULTS
             // read participants' responses 
             for (int i = 0; i < _pageFactory.GetComponent<PageFactory>().QuestionList.Count; i++)
             {
@@ -255,6 +256,7 @@ namespace VRQuestionnaireToolkit
                     }
                 }
             }
+            #endregion
 
             // disable all GameObjects (except the last page) 
             for (int i = 1; i < _pageFactory.GetComponent<PageFactory>().NumPages - 1; i++)
@@ -311,6 +313,12 @@ namespace VRQuestionnaireToolkit
             QuestionnaireFinishedEvent.Invoke(); //notify 
         }
 
+        /// <summary>
+        /// Consolidate all results to a StringBuilder, written to be directly written.
+        /// </summary>
+        /// <param name="filepath"></param>
+        /// <param name="newData"></param>
+        /// <returns></returns>
         StringBuilder GetConsolidatedContent(string filepath, string[][] newData)
         {
             StringBuilder sb_all_content = new StringBuilder();
@@ -345,6 +353,11 @@ namespace VRQuestionnaireToolkit
             return sb_all_content;
         }
 
+        /// <summary>
+        /// Write a StringBuilder to a local file.
+        /// </summary>
+        /// <param name="localPath"></param>
+        /// <param name="content"></param>
         void WriteToLocal(string localPath, StringBuilder content)
         {
             print("Answers stored in path: " + localPath);
@@ -389,6 +402,11 @@ namespace VRQuestionnaireToolkit
             }
         }
 
+        /// <summary>
+        /// Check if the provided server URI is valid.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <returns></returns>
         IEnumerator CheckURIValidity(string uri)
         {
             UnityWebRequest www = new UnityWebRequest(uri);

--- a/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
+++ b/Questionnaires/Questionnaire/Assets/Questionnaires/Scripts/Export/ExportToCSV.cs
@@ -26,6 +26,12 @@ namespace VRQuestionnaireToolkit
     {
         public string FileName;
         public string Delimiter;
+        public enum FileType
+        {
+            Csv,
+            Txt
+        }
+        public FileType Filetype;
 
         [Header("Configure if you want to save the results to local storage:")]
         [Tooltip("Save results locally on this device.")]
@@ -45,14 +51,6 @@ namespace VRQuestionnaireToolkit
         private string _folderPath;
         private string _fileType;
         private string _questionnaireID;
-
-        public enum FileType
-        {
-            Csv,
-            Txt
-        }
-
-        public FileType Filetype;
 
         public UnityEvent QuestionnaireFinishedEvent;
 

--- a/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php
+++ b/Questionnaires/Questionnaire/Assets/Resources/Templates/survey-results.php
@@ -1,11 +1,11 @@
 <?php
 	// php template for receiving the result data.
 	// place this file under the directory where you want to store the result data on your server.
-	// for customisation, see also ExportToCSV.cs, line 342.
+	// for customisation, see also ExportToCSV.cs.
  
 	$fileName = $_POST["fileName"];
 	$inputData = $_POST["inputData"];
 	$file = fopen($fileName, "w") or die("Unable to open file!");
 	fwrite($file, $inputData);
-	echo "Results written in $fileName.";
+	echo "Results written remotely at $fileName.";
 ?>


### PR DESCRIPTION
User can now choose to save results to local storage and/or remote server separately.
Also improved usability:
- if local-save is on, the provided folder path will be verified at the start of the application, if it doesn't exist, a new folder will be created.
- if remote-save is on, the provided server uri will be verified at the start of the application.
- if neither of the save options in on, the user will be warned that the data will be lost at the start of the application.